### PR TITLE
Build binaries using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           cmd /C $f
         }
       working-directory: cb/bld
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v2
       with:
         name: bin-${{ matrix.os }}
         path: cb/bld/bin
@@ -111,15 +111,15 @@ jobs:
           rm -fr bin/e_sqlite3
           rm -fr bin/e_sqlcipher
         working-directory: bld
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           name: bin-ubuntu-latest
           path: bld/bin
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           name: bin-macos-latest
           path: bld/bin
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           name: bin-windows-latest
           path: bld/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         repository: libtom/libtomcrypt
         path: "libtomcrypt"
-        ref: "5a3a12c9b343e219a0a1cbc3c47e997e5a39ffa6"
+        ref: "v1.18.2"
     - name: Setup cross compilers
       if: startsWith(matrix.os, 'ubuntu')
       run: ./cb/bld/setup_linux.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,137 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - 'bld/bin/**'
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - 'bld/bin/**'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: "cb"
+    - uses: actions/checkout@v2
+      with:
+        repository: libtom/libtomcrypt
+        path: "libtomcrypt"
+        ref: "5a3a12c9b343e219a0a1cbc3c47e997e5a39ffa6"
+    - name: Setup cross compilers
+      if: startsWith(matrix.os, 'ubuntu')
+      run: ./cb/bld/setup_linux.sh
+    - name: Setup NDK
+      if: startsWith(matrix.os, 'ubuntu')
+      uses: nttld/setup-ndk@v1
+      with:
+        ndk-version: r21e
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Generate script
+      run: dotnet run
+      working-directory: cb/bld
+    - name: Update permissions
+      run: chmod +x *.sh 
+      working-directory: cb/bld
+    - name: Clean output directory
+      if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+      run: rm -fr bin
+      working-directory: cb/bld
+    - name: Clean output directory
+      if: startsWith(matrix.os, 'windows')
+      run: rm bin -r -fo
+      working-directory: cb/bld
+    - name: Build (Linux)
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        #!/bin/bash
+        set -e
+        for f in linux_*.sh; do
+          if [[ "$f" == *_cross.sh ]] || [[ "$f" == *_regular.sh ]]
+          then
+            continue
+          fi
+          bash "$f"
+        done
+      working-directory: cb/bld
+    - name: Build (Android)
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        set -e
+        cd android_e_sqlite3
+        ndk-build
+        mkdir -p ../bin/e_sqlite3/android
+        cp -r libs/* ../bin/e_sqlite3/android
+        cd ../android_e_sqlcipher
+        ndk-build
+        mkdir -p ../bin/e_sqlcipher/android
+        cp -r libs/* ../bin/e_sqlcipher/android
+      working-directory: cb/bld
+    - name: Build (macOS, iOS, tvOS)
+      if: startsWith(matrix.os, 'macos')
+      run: |
+        set -e
+        for f in mac_*.sh ios_*.sh tvos_*.sh; do
+          bash "$f"
+        done
+      working-directory: cb/bld
+    - name: Build (Windows)
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        $files = Get-ChildItem *.bat -Exclude "win_e_sqlite3.bat","win_e_sqlcipher.bat"
+        foreach ($f in $files) {
+          cmd /C $f
+        }
+      working-directory: cb/bld
+    - uses: actions/upload-artifact@master
+      with:
+        name: bin-${{ matrix.os }}
+        path: cb/bld/bin
+
+  publish:
+    needs: build
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Clean output directory
+        run: |
+          rm -fr bin/e_sqlite3
+          rm -fr bin/e_sqlcipher
+        working-directory: bld
+      - uses: actions/download-artifact@master
+        with:
+          name: bin-ubuntu-latest
+          path: bld/bin
+      - uses: actions/download-artifact@master
+        with:
+          name: bin-macos-latest
+          path: bld/bin
+      - uses: actions/download-artifact@master
+        with:
+          name: bin-windows-latest
+          path: bld/bin
+      - name: Fix permissions
+        run: |
+          find ./bld/bin/e_sqlite3 -name *.so | xargs chmod 0775
+          find ./bld/bin/e_sqlite3 -name *.dylib | xargs chmod 0775
+          find ./bld/bin/e_sqlcipher -name *.so | xargs chmod 0775
+          find ./bld/bin/e_sqlcipher -name *.dylib | xargs chmod 0775
+      - name: Commit & Push changes
+        uses: actions-js/push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "refs/heads/staging"
+          force: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
-      - 'bld/bin/**'
+    - 'bld/bin/**'
   pull_request:
     branches: [ master ]
     paths-ignore:
-      - 'bld/bin/**'
+    - 'bld/bin/**'
 
 jobs:
   build:
@@ -98,40 +98,98 @@ jobs:
         name: bin-${{ matrix.os }}
         path: cb/bld/bin
 
+  test:
+    needs: build
+    if: ${{ github.event_name == 'pull_request' }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: "cb"
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        repository: ericsink/SQLitePCL.raw
+        path: "SQLitePCL.raw"
+    - name: Clean output directory
+      if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+      run: rm -fr bin
+      working-directory: cb/bld
+    - name: Clean output directory
+      if: startsWith(matrix.os, 'windows')
+      run: rm bin -r -fo
+      working-directory: cb/bld
+    - uses: actions/download-artifact@v2
+      with:
+        name: bin-ubuntu-latest
+        path: cb/bld/bin
+    - uses: actions/download-artifact@v2
+      with:
+        name: bin-macos-latest
+        path: cb/bld/bin
+    - uses: actions/download-artifact@v2
+      with:
+        name: bin-windows-latest
+        path: cb/bld/bin
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - name: Setup .NET 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Setup .NET 2.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.x
+    - name: Add msbuild to PATH
+      if: startsWith(matrix.os, 'windows')
+      uses: microsoft/setup-msbuild@v1.0.2
+    - name: Install T4
+      run: dotnet tool install --global dotnet-t4
+    - name: Build
+      run: |
+        cd SQLitePCL.raw/build
+        dotnet run
+
   publish:
     needs: build
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Clean output directory
-        run: |
-          rm -fr bin/e_sqlite3
-          rm -fr bin/e_sqlcipher
-        working-directory: bld
-      - uses: actions/download-artifact@v2
-        with:
-          name: bin-ubuntu-latest
-          path: bld/bin
-      - uses: actions/download-artifact@v2
-        with:
-          name: bin-macos-latest
-          path: bld/bin
-      - uses: actions/download-artifact@v2
-        with:
-          name: bin-windows-latest
-          path: bld/bin
-      - name: Fix permissions
-        run: |
-          find ./bld/bin/e_sqlite3 -name *.so | xargs chmod 0775
-          find ./bld/bin/e_sqlite3 -name *.dylib | xargs chmod 0775
-          find ./bld/bin/e_sqlcipher -name *.so | xargs chmod 0775
-          find ./bld/bin/e_sqlcipher -name *.dylib | xargs chmod 0775
-      - name: Commit & Push changes
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "refs/heads/staging"
-          force: true
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clean output directory
+      run: |
+        rm -fr bin/e_sqlite3
+        rm -fr bin/e_sqlcipher
+      working-directory: bld
+    - uses: actions/download-artifact@v2
+      with:
+        name: bin-ubuntu-latest
+        path: bld/bin
+    - uses: actions/download-artifact@v2
+      with:
+        name: bin-macos-latest
+        path: bld/bin
+    - uses: actions/download-artifact@v2
+      with:
+        name: bin-windows-latest
+        path: bld/bin
+    - name: Fix permissions
+      run: |
+        find ./bld/bin/e_sqlite3 -name *.so | xargs chmod 0775
+        find ./bld/bin/e_sqlite3 -name *.dylib | xargs chmod 0775
+        find ./bld/bin/e_sqlcipher -name *.so | xargs chmod 0775
+        find ./bld/bin/e_sqlcipher -name *.dylib | xargs chmod 0775
+    - name: Commit & Push changes
+      uses: actions-js/push@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: "refs/heads/staging"
+        force: true

--- a/bld/cb.cs
+++ b/bld/cb.cs
@@ -491,7 +491,7 @@ public static class cb
 		};
 		var arches_device = new string[] {
 			"arm64",
-			"armv7",
+			//"armv7",
 			//"armv7s",
 		};
 		var arches = arches_simulator.Concat(arches_device).ToArray();
@@ -563,10 +563,10 @@ public static class cb
 			tw.Write($"libtool -static -o {path_static} -filelist {dest_filelist}\n");
 
 			tw.Write("mkdir -p \"./bin/{0}/tvos/device\"\n", libname);
-			tw.Write($"xcrun --sdk iphoneos clang {string.Join(" ", arches_device.Select(s => $"-arch {s}"))} -shared -all_load -o ./bin/{libname}/tvos/device/lib{libname}.dylib {path_static}\n");
+			tw.Write($"xcrun --sdk appletvos clang {string.Join(" ", arches_device.Select(s => $"-arch {s}"))} -shared -all_load -o ./bin/{libname}/tvos/device/lib{libname}.dylib {path_static}\n");
 
 			tw.Write("mkdir -p \"./bin/{0}/tvos/simulator\"\n", libname);
-			tw.Write($"xcrun --sdk iphonesimulator clang {string.Join(" ", arches_simulator.Select(s => $"-arch {s}"))} -shared -all_load -o ./bin/{libname}/tvos/simulator/lib{libname}.dylib {path_static}\n");
+			tw.Write($"xcrun --sdk appletvsimulator clang {string.Join(" ", arches_simulator.Select(s => $"-arch {s}"))} -shared -all_load -o ./bin/{libname}/tvos/simulator/lib{libname}.dylib {path_static}\n");
 		}
 	}
 
@@ -1775,7 +1775,7 @@ public static class cb
 			var defines = new Dictionary<string,string>
 			{
 				{ "_WIN32", null }, // for tomcrypt
-				{ "ENDIAN_LITTLE", null }, // for tomcrypt arm
+				{ "ENDIAN_LITTLE", "" }, // for tomcrypt arm
 				{ "LTC_NO_PROTOTYPES", null },
 				{ "LTC_SOURCE", null },
 				{ "SQLITE_HAS_CODEC", null },
@@ -1869,7 +1869,7 @@ public static class cb
 			var defines = new Dictionary<string,string>
 			{
 				//{ "_WIN32", null }, // for tomcrypt
-				{ "ENDIAN_LITTLE", null }, // for tomcrypt arm
+				{ "ENDIAN_LITTLE", "" }, // for tomcrypt arm
 				{ "LTC_NO_PROTOTYPES", null },
 				{ "LTC_SOURCE", null },
 				{ "SQLITE_HAS_CODEC", null },
@@ -1925,7 +1925,7 @@ public static class cb
 			var defines = new Dictionary<string,string>
 			{
 				//{ "_WIN32", null }, // for tomcrypt
-				{ "ENDIAN_LITTLE", null }, // for tomcrypt arm
+				{ "ENDIAN_LITTLE", "" }, // for tomcrypt arm
 				{ "LTC_NO_PROTOTYPES", null },
 				{ "LTC_SOURCE", null },
 				{ "SQLITE_HAS_CODEC", null },
@@ -1977,7 +1977,7 @@ public static class cb
 			var defines = new Dictionary<string,string>
 			{
 				//{ "_WIN32", null }, // for tomcrypt
-				{ "ENDIAN_LITTLE", null }, // for tomcrypt arm
+				{ "ENDIAN_LITTLE", "" }, // for tomcrypt arm
 				{ "LTC_NO_PROTOTYPES", null },
 				{ "LTC_SOURCE", null },
 				{ "SQLITE_HAS_CODEC", null },

--- a/bld/setup_linux.sh
+++ b/bld/setup_linux.sh
@@ -1,4 +1,10 @@
-#1/bin/sh
+#!/bin/sh
+
+sudo dpkg --add-architecture i386
+sudo apt-get update
+sudo apt-get install linux-libc-dev:i386
+sudo apt-get install gcc-multilib
+
 sudo apt-get install gcc-arm-linux-gnueabi
 sudo apt-get install gcc-arm-linux-gnueabihf
 sudo apt-get install musl-dev musl-tools


### PR DESCRIPTION
This builds all the binaries on hosted GitHub Actions machines. It uploads the resulting binaries as pipeline artifacts that can be downloaded once the build finishes.

On pull requests the builds artifacts are fed into second job that runs full SQLitePCL.Raw build with unit tests to ensure that nothing gets broken.

Additionally, when a PR is merged into `master` it does the build again and creates a `staging` branch that contains auto-generated commit with all the new binaries.