### PR TITLE
Build musl arm (armhf) too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         #!/bin/bash
+        export PATH="$PWD/../../crosscompilers/bin:$PATH"
         set -e
         for f in linux_*.sh; do
           if [[ "$f" == *_cross.sh ]] || [[ "$f" == *_regular.sh ]]

--- a/bld/cb.cs
+++ b/bld/cb.cs
@@ -174,6 +174,10 @@ public static class cb
 					tw.Write(" -m64\n");
 					break;
 
+				case "musl-armhf":
+					compiler = "arm-linux-musleabihf-cc";
+					break;
+
 				default:
 					throw new NotImplementedException();
 			}
@@ -1210,6 +1214,7 @@ public static class cb
 			var targets_cross = new linux_target[]
 			{
 				new linux_target("musl-x64"),
+				new linux_target("musl-armhf"),
 				new linux_target("arm64"),
 				new linux_target("armhf"),
 				new linux_target("armsf"),
@@ -1900,6 +1905,7 @@ public static class cb
 			var targets_cross = new linux_target[]
 			{
 				new linux_target("musl-x64"),
+				new linux_target("musl-armhf"),
 				new linux_target("arm64"),
 				new linux_target("armhf"),
 				new linux_target("armsf"),

--- a/bld/setup_linux.sh
+++ b/bld/setup_linux.sh
@@ -11,3 +11,9 @@ sudo apt-get install musl-dev musl-tools
 sudo apt-get install gcc-aarch64-linux-gnu
 sudo apt-get install gcc-mips64el-linux-gnuabi64
 sudo apt-get install gcc-s390x-linux-gnu
+
+mkdir crosscompilers
+cd crosscompilers
+wget -q https://musl.cc/arm-linux-musleabihf-cross.tgz
+tar --strip-components=1 -zxf ./arm-linux-musleabihf-cross.tgz
+cd ..


### PR DESCRIPTION
Can build armsf and arm64 this way too (see my [muslarm branch](https://github.com/danzel/cb/tree/muslarm)), but I haven't tested them so I'm not including them.

I have tested the built .so file on alpine arm and it worked.

Refs https://github.com/ericsink/SQLitePCL.raw/issues/453