### PR TITLE
Set install name for macOS to @rpath-based path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,10 @@ jobs:
       with:
         name: bin-windows-latest
         path: cb/bld/bin
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:

--- a/bld/cb.cs
+++ b/bld/cb.cs
@@ -381,6 +381,7 @@ public static class cb
 				tw.Write(" --sdk macosx");
 				tw.Write(" clang");
 				tw.Write(" -dynamiclib");
+				tw.Write(" -install_name @rpath/lib{0}.dylib", libname);
 				tw.Write(" -O");
 				tw.Write(" -arch {0}", arch);
 				foreach (var d in defines.Keys.OrderBy(q => q))


### PR DESCRIPTION
Fixes linking in newer .NET 6 Previews where the `libe_sqlite3.dylib` would have been linked with incorrect relative path (`./bin/e_sqlite3/mac/arm64/libe_sqlite3.dylib`) into the final executable resulting in this:

```
/Users/filipnavara/Projects/emclient-temp/MailClient/bin/Debug/net6.0-macos/eM Client.app/Contents/MacOS/eM Client:
    @rpath/libSystem.Globalization.Native.dylib (compatibility version 0.0.0, current version 0.0.0)
        ...
    ./bin/e_sqlite3/mac/arm64/libe_sqlite3.dylib (compatibility version 0.0.0, current version 0.0.0)
``` 

The executable would not start because the relative path doesn't exist.