### PR TITLE
Add static libraries for Emscripten (Wasm)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,11 @@ jobs:
       uses: nttld/setup-ndk@v1
       with:
         ndk-version: r21e
+    - name: Setup Emscripten
+      if: startsWith(matrix.os, 'ubuntu')
+      uses: mymindstorm/setup-emsdk@v11
+      with:
+        version: 2.0.23 # NB: Matches .NET 6
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -76,6 +81,15 @@ jobs:
         ndk-build
         mkdir -p ../bin/e_sqlcipher/android
         cp -r libs/* ../bin/e_sqlcipher/android
+      working-directory: cb/bld
+    - name: Build (Wasm)
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        #!/bin/bash
+        set -e
+        for f in wasm_*.sh; do
+          bash "$f"
+        done
       working-directory: cb/bld
     - name: Build (macOS, iOS, tvOS)
       if: startsWith(matrix.os, 'macos')

--- a/bld/clean_scripts.sh
+++ b/bld/clean_scripts.sh
@@ -6,6 +6,7 @@ rm ./win_*.bat
 rm ./*.buildoutput.txt
 rm ./linux_*.sh
 #rm ./android_*.sh
+rm ./wasm_*.sh
 rm ./ios_*.sh
 rm ./tvos_*.sh
 rm ./mac_*.sh


### PR DESCRIPTION
I'm still working on the changes to SQLitePCLRaw, but I think this part is done and ready for review.

Emscripten supports [faux dynamic linking](https://emscripten.org/docs/compiling/Building-Projects.html#faux-dynamic-linking) via `-shared` and `.so` files, but at the end of the day, it's really just static linking via combined object files. The approach I've chosen (using `.a` files) seems more honest and is more consistent with the AOT platforms that are already supported.

Part of #4

/cc @ajcvickers