### PR TITLE
Add support for linux-musl-s390x target

### DIFF
--- a/bld/cb.cs
+++ b/bld/cb.cs
@@ -192,6 +192,10 @@ public static class cb
 					compiler = "aarch64-linux-musl-cc";
 					break;
 
+				case "musl-s390x":
+					compiler = "s390x-linux-musl-cc";
+					break;
+
 				default:
 					throw new NotImplementedException();
 			}
@@ -1384,6 +1388,7 @@ public static class cb
 				new linux_target("musl-x64"),
 				new linux_target("musl-arm64"),
 				new linux_target("musl-armhf"),
+				new linux_target("musl-s390x"),
 				new linux_target("arm64"),
 				new linux_target("armhf"),
 				new linux_target("armsf"),
@@ -2474,6 +2479,7 @@ public static class cb
 
 			var targets_cross = new linux_target[]
 			{
+				new linux_target("musl-s390x"),
 				new linux_target("s390x"),
 				new linux_target("ppc64le"),
 			};

--- a/bld/setup_linux.sh
+++ b/bld/setup_linux.sh
@@ -21,4 +21,6 @@ tar --strip-components=1 -zxf ./arm-linux-musleabihf-cross.tgz
 wget https://musl.cc/aarch64-linux-musl-cross.tgz
 #wget https://ericsink.com/aarch64-linux-musl-cross.tgz
 tar --strip-components=1 -zxf aarch64-linux-musl-cross.tgz
+wget https://musl.cc/s390x-linux-musl-cross.tgz
+tar --strip-components=1 -zxf s390x-linux-musl-cross.tgz
 cd ..


### PR DESCRIPTION
This addresses the "cb" portion of https://github.com/ericsink/SQLitePCL.raw/issues/571.

Note that to build the musl binary, this uses the s390x cross-compiler provided on `musl.cc` same as for the other architectures.
