### PR TITLE
Add support for linux-musl-s390x target (sqlite3mc)

### DIFF
--- a/bld/cb.cs
+++ b/bld/cb.cs
@@ -1671,6 +1671,7 @@ public static class cb
 				new linux_target("musl-x64"),
 				new linux_target("musl-arm64"),
 				new linux_target("musl-armhf"),
+				new linux_target("musl-s390x"),
 				new linux_target("arm64"),
 				new linux_target("armhf"),
 				new linux_target("armsf"),


### PR DESCRIPTION
Add missing sqlite3mc support for linux-musl-s390x - remaining part of https://github.com/ericsink/SQLitePCL.raw/issues/571.