### PR TITLE
add riscv64 build

### DIFF
--- a/bld/cb.cs
+++ b/bld/cb.cs
@@ -1682,12 +1682,14 @@ public static class cb
 				new linux_target("musl-arm64"),
 				new linux_target("musl-armhf"),
 				new linux_target("musl-s390x"),
+				new linux_target("musl-riscv64"),
 				new linux_target("arm64"),
 				new linux_target("armhf"),
 				new linux_target("armsf"),
 				new linux_target("mips64"),
 				new linux_target("s390x"),
 				new linux_target("ppc64le"),
+				new linux_target("riscv64"),
 			};
 
 			write_linux_multi(

--- a/bld/cb.cs
+++ b/bld/cb.cs
@@ -177,6 +177,10 @@ public static class cb
 					compiler = "arm-linux-gnueabi-gcc";
 					break;
 
+				case "riscv64":
+					compiler = "riscv64-linux-gnu-gcc";
+					break;
+
 				case "musl-x64":
 					compiler = "musl-gcc";
 					tw.Write(" -m64\n");
@@ -194,6 +198,10 @@ public static class cb
 
 				case "musl-s390x":
 					compiler = "s390x-linux-musl-cc";
+					break;
+
+				case "musl-riscv64":
+					compiler = "riscv64-linux-musl-cc";
 					break;
 
 				default:
@@ -1389,12 +1397,14 @@ public static class cb
 				new linux_target("musl-arm64"),
 				new linux_target("musl-armhf"),
 				new linux_target("musl-s390x"),
+				new linux_target("musl-riscv64"),
 				new linux_target("arm64"),
 				new linux_target("armhf"),
 				new linux_target("armsf"),
 				new linux_target("mips64"),
 				new linux_target("s390x"),
 				new linux_target("ppc64le"),
+				new linux_target("riscv64"),
 			};
 
 			write_linux_multi(
@@ -2481,8 +2491,10 @@ public static class cb
 			var targets_cross = new linux_target[]
 			{
 				new linux_target("musl-s390x"),
+				new linux_target("musl-riscv64"),
 				new linux_target("s390x"),
 				new linux_target("ppc64le"),
+				new linux_target("riscv64"),
 			};
 
 			write_linux_multi(
@@ -2819,12 +2831,14 @@ public static class cb
 				new linux_target("musl-x64"),
 				new linux_target("musl-arm64"),
 				new linux_target("musl-armhf"),
+				new linux_target("musl-riscv64"),
 				new linux_target("arm64"),
 				new linux_target("armhf"),
 				new linux_target("armsf"),
 				new linux_target("mips64"),
 				new linux_target("s390x"),
 				new linux_target("ppc64le"),
+				new linux_target("riscv64"),
 			};
 
 			write_linux_multi(
@@ -3010,4 +3024,3 @@ public static class cb
         write_sqlite3mc();
     }
 }
-

--- a/bld/setup_linux.sh
+++ b/bld/setup_linux.sh
@@ -12,6 +12,7 @@ sudo apt-get install gcc-aarch64-linux-gnu
 sudo apt-get install gcc-mips64el-linux-gnuabi64
 sudo apt-get install gcc-s390x-linux-gnu
 sudo apt-get install gcc-powerpc64le-linux-gnu
+sudo apt-get install gcc-riscv64-linux-gnu
 
 mkdir crosscompilers
 cd crosscompilers
@@ -23,4 +24,6 @@ wget https://musl.cc/aarch64-linux-musl-cross.tgz
 tar --strip-components=1 -zxf aarch64-linux-musl-cross.tgz
 wget https://musl.cc/s390x-linux-musl-cross.tgz
 tar --strip-components=1 -zxf s390x-linux-musl-cross.tgz
+wget https://musl.cc/riscv64-linux-musl-cross.tgz
+tar --strip-components=1 -zxf riscv64-linux-musl-cross.tgz
 cd ..


### PR DESCRIPTION
riscv64 support was recently added in dotnet sdk and community runtime builds are available for use.