### PR TITLE
Add support for loongarch64

### DIFF
--- a/bld/cb.cs
+++ b/bld/cb.cs
@@ -181,9 +181,9 @@ public static class CB
 					compiler = "riscv64-linux-gnu-gcc";
 					break;
 
-                case "loongarch64":
-                    compiler = "loongarch64-unknown-linux-gnu-gcc";
-                    break;
+				case "loongarch64":
+					compiler = "loongarch64-unknown-linux-gnu-gcc";
+					break;
 
 				case "musl-x64":
 					compiler = "musl-gcc";

--- a/bld/cb.cs
+++ b/bld/cb.cs
@@ -181,6 +181,10 @@ public static class CB
 					compiler = "riscv64-linux-gnu-gcc";
 					break;
 
+                case "loongarch64":
+                    compiler = "loongarch64-unknown-linux-gnu-gcc";
+                    break;
+
 				case "musl-x64":
 					compiler = "musl-gcc";
 					tw.Write(" -m64\n");
@@ -1406,6 +1410,7 @@ public static class CB
 				new linux_target("s390x"),
 				new linux_target("ppc64le"),
 				new linux_target("riscv64"),
+                new linux_target("loongarch64"),
 			};
 
 			write_linux_multi(
@@ -1691,6 +1696,7 @@ public static class CB
 				new linux_target("s390x"),
 				new linux_target("ppc64le"),
 				new linux_target("riscv64"),
+                new linux_target("loongarch64"),
 			};
 
 			write_linux_multi(
@@ -2498,6 +2504,7 @@ public static class CB
 				new linux_target("s390x"),
 				new linux_target("ppc64le"),
 				new linux_target("riscv64"),
+                new linux_target("loongarch64"),
 			};
 
 			write_linux_multi(
@@ -2842,6 +2849,7 @@ public static class CB
 				new linux_target("s390x"),
 				new linux_target("ppc64le"),
 				new linux_target("riscv64"),
+                new linux_target("loongarch64"),
 			};
 
 			write_linux_multi(

--- a/bld/setup_linux.sh
+++ b/bld/setup_linux.sh
@@ -26,4 +26,6 @@ wget https://musl.cc/s390x-linux-musl-cross.tgz
 tar --strip-components=1 -zxf s390x-linux-musl-cross.tgz
 wget https://musl.cc/riscv64-linux-musl-cross.tgz
 tar --strip-components=1 -zxf riscv64-linux-musl-cross.tgz
+wget https://github.com/loongson/build-tools/releases/download/2024.11.01/x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz
+tar --strip-components=1 -zxf x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz
 cd ..

--- a/bld/setup_linux.sh
+++ b/bld/setup_linux.sh
@@ -27,5 +27,5 @@ tar --strip-components=1 -zxf s390x-linux-musl-cross.tgz
 wget https://musl.cc/riscv64-linux-musl-cross.tgz
 tar --strip-components=1 -zxf riscv64-linux-musl-cross.tgz
 wget https://github.com/loongson/build-tools/releases/download/2024.11.01/x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz
-tar --strip-components=1 -zxf x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz
+tar --strip-components=1 -xf x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz
 cd ..


### PR DESCRIPTION
Artifacts are used in osu!lazer and work well.